### PR TITLE
initialize cursor position in setup

### DIFF
--- a/lua/YankAssassin/init.lua
+++ b/lua/YankAssassin/init.lua
@@ -72,7 +72,7 @@ function M.setup(opts)
 	opts = opts or {}
 	auto_normal = opts.auto_normal or false
 	auto_visual = opts.auto_visual or false
-
+	pre_yank_pos = vim.api.nvim_win_get_cursor(0)
 	if auto_normal or auto_visual then
 		setup_autocmds()
 	end

--- a/lua/YankAssassin/init.lua
+++ b/lua/YankAssassin/init.lua
@@ -17,10 +17,7 @@ end
 
 -- Function to restore the cursor position after yanking
 local function post_yank_motion()
- if not (pre_yank_pos and #pre_yank_pos == 2) then
-        pre_yank_pos = vim.api.nvim_win_get_cursor(0)
-end
-        vim.api.nvim_win_set_cursor(0, pre_yank_pos)
+	vim.api.nvim_win_set_cursor(0, pre_yank_pos)
 end
 
 local function setup_autocmds()

--- a/lua/YankAssassin/init.lua
+++ b/lua/YankAssassin/init.lua
@@ -17,7 +17,10 @@ end
 
 -- Function to restore the cursor position after yanking
 local function post_yank_motion()
-	vim.api.nvim_win_set_cursor(0, pre_yank_pos)
+ if not (pre_yank_pos and #pre_yank_pos == 2) then
+        pre_yank_pos = vim.api.nvim_win_get_cursor(0)
+end
+        vim.api.nvim_win_set_cursor(0, pre_yank_pos)
 end
 
 local function setup_autocmds()


### PR DESCRIPTION
This allows the plugin to be lazy loaded, for example with 'VeryLazy' using [lazy.nvim](https://github.com/folke/lazy.nvim)   .  Otherwise, there is an error if the user uses as the loading event 'VeryLazy' and attempts to yank before moving the cursor. 